### PR TITLE
todo-listをmat-listからmat-cardの繰り返しに変更

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,3 @@
+::ng-deep body{
+  background-color: #fafafa;
+}

--- a/src/app/views/todo/todo-list/todo-list.component.html
+++ b/src/app/views/todo/todo-list/todo-list.component.html
@@ -1,35 +1,31 @@
 <!-- 全てのtodoのリスト -->
 <div class="todo-list-component">
   <h2 class="todo-list-component__title">Todo 一覧</h2>
-  <mat-list class="todo-list-component__todo-list">
-    <mat-divider></mat-divider>
-    <mat-list-item class="todo-item" *ngFor="let todo of (todos$ | async)">
-      <!-- タイトル -->
-      <p class="todo-item__title" matLine>{{todo.title}}</p>
-      <!-- 補足情報 -->
-      <p class="todo-item__sub-info" matLine>
-        <!-- ステータス -->
-        <span class="todo-item__status">{{todo.state.name}}</span>
-        <!-- 対応するカテゴリ -->
-        <span class="todo-item__category" *ngIf="getCategoryById(todo.categoryId, categories$|async) as category" >
-          <!-- カテゴリの色 -->
-          <fa-icon class="todo-item__category-color" [icon]="faCircle" [style.color]="category.color | colorToRgb"></fa-icon>
-          <!-- カテゴリのスラグ -->
-          <span class="todo-item__category-slug">{{category.slug}}</span>
-        </span>
+  <mat-card class="todo-item" *ngFor="let todo of (todos$ | async)">
+    <!-- タイトル -->
+    <mat-card-title class="todo-item__title">{{todo.title}}</mat-card-title>
+    <!-- 補足情報 -->
+    <mat-card-subtitle class="todo-item__sub-info">
+      <!-- ステータス -->
+      <p class="todo-item__status">{{todo.state.name}}</p>
+      <!-- 対応するカテゴリ -->
+      <p class="todo-item__category" *ngIf="getCategoryById(todo.categoryId, categories$|async) as category" >
+        <!-- カテゴリの色 -->
+        <fa-icon class="todo-item__category-color" [icon]="faCircle" [style.color]="category.color | colorToRgb"></fa-icon>
+        <!-- カテゴリのスラグ -->
+        <span class="todo-item__category-slug">{{category.slug}}</span>
       </p>
-      <!-- 本文 -->
-      <p class="todo-item__body" matLine *ngIf="todo.body">{{todo.body}}</p>
-      <!-- フッター -->
-      <p class="todo-item__footer" matLine>
-        <!-- 更新ボタン -->
-        <fa-icon class="todo-item__edit-btn" [icon]="faEdit" (click)="showEditDialog(todo)"></fa-icon>
-        <!-- 削除ボタン -->
-        <fa-icon class="todo-item__delete-btn" [icon]="faTrashAlt" (click)="deleteComponent(todo.id)"></fa-icon>
-      </p>
-      <mat-divider></mat-divider>
-    </mat-list-item>
-  </mat-list>
+    </mat-card-subtitle>
+    <!-- 本文 -->
+    <mat-card-content class="todo-item__body" *ngIf="todo.body">{{todo.body}}</mat-card-content>
+    <!-- フッター -->
+    <mat-card-actions class="todo-item__footer">
+      <!-- 更新ボタン -->
+      <fa-icon class="todo-item__edit-btn" [icon]="faEdit" (click)="showEditDialog(todo)"></fa-icon>
+      <!-- 削除ボタン -->
+      <fa-icon class="todo-item__delete-btn" [icon]="faTrashAlt" (click)="deleteComponent(todo.id)"></fa-icon>
+    </mat-card-actions>
+  </mat-card>
   <!-- 追加ボタン -->
   <fa-icon class="todo-list-component__store-btn" [icon]="faPlusCircle" (click)="showStoreDialog()"></fa-icon>
 </div>

--- a/src/app/views/todo/todo-list/todo-list.component.scss
+++ b/src/app/views/todo/todo-list/todo-list.component.scss
@@ -2,47 +2,34 @@
   // store-btnをcontentsエリアに含めるように
   display: flow-root;
 
-  width: 1000px;
-  margin-right: auto;
-
-  &__title{
-    margin: 10px 0 10px 0;
-  }
+  width:     85%;
+  max-width: 700px;
+  margin:    0 auto;
 
   &__store-btn{
     // todo-listに粘着表示するように
     position: sticky;
-    bottom: 40px;
-    right: 40px;
+    bottom:   25px;
+    right:    25px;
 
-    float: right;
-    margin: 40px;
-    color: black;
+    float:     right;
+    margin:    25px;
+    color:     black;
     font-size: 2.5em;
-  }
-
-  &__todo-list{
-    // mat-listで設定されているpaddingを削除
-    padding: 0;
   }
 }
 
 .todo-item{
-
-  &__title{
-    font-size: 1.5em !important;
-  }
+  margin-bottom: 10px;
 
   &__sub-info{
-    margin-left: 0.5em !important;
-    display:     flex !important;
+    display: flex;
+    margin:  0 0 8px 4px;
   }
 
   &__status {
-    display: inline-block;
-    width:   5em;
+    width:   56px;
     margin:  auto 0;
-    color:   gray;
   }
 
   &__category{
@@ -51,38 +38,29 @@
   }
 
   &__category-color{
-    width:     auto;
-    height:    auto;
-    margin:    auto 0.25em auto 0;
-    font-size: 1em;
-  }
-
-  &__category-slug{
-    margin: auto 0;
-    color:  gray;
+    margin-right: 2px;
   }
 
   &__body{
-    margin-left: 0.5em !important;
-    white-space: pre-wrap !important;
+    margin:      0 0 8px 4px;
+    white-space: pre-wrap;
   }
 
   &__footer {
-    margin-left: 0.5em !important;
+    margin:          0 !important;
+    // 初期設定されているpaddingを取り除く
+    padding-top:     0;
+    justify-content: end;
+    display:         flex;
   }
 
   &__edit-btn {
     font-size: 1.25em;
-    margin-right: 0.5em;
   }
 
   &__delete-btn {
-    font-size: 1.25em;
+    margin-left: 16px;
+    font-size:   1.25em;
   }
 }
 
-// bodyがある場合とそうでない場合で適用されるpadding,heightが違うため、統一する
-:host ::ng-deep .mat-list-item-content {
-  height: auto !important;
-  padding: 10px !important;
-}

--- a/src/app/views/todo/todo.module.ts
+++ b/src/app/views/todo/todo.module.ts
@@ -1,7 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { TodoListComponent } from './todo-list/todo-list.component';
-import { MatListModule } from '@angular/material/list'
 import { PipeModule } from '../../pipe/pipe.module';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { TodoFormDialogComponent } from './todo-form-dialog/todo-form-dialog.component';
@@ -14,6 +13,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { TodoFormComponent } from './todo-form/todo-form.component';
 import { MatRadioModule } from '@angular/material/radio'
 import { MatSnackBarModule } from '@angular/material/snack-bar'
+import { MatCardModule } from '@angular/material/card'
 
 @NgModule({
   declarations: [
@@ -23,7 +23,6 @@ import { MatSnackBarModule } from '@angular/material/snack-bar'
   ],
   imports: [
     CommonModule,
-    MatListModule,
     PipeModule,
     FontAwesomeModule,
     MatDialogModule,
@@ -34,6 +33,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar'
     ReactiveFormsModule,
     MatRadioModule,
     MatSnackBarModule,
+    MatCardModule,
   ]
 })
 export class TodoModule { }


### PR DESCRIPTION
## 変更内容
- カードを見やすくするため、背景色を#fafafaに変更 [c757577](https://github.com/yasu307/todo-app-angular/pull/5/commits/c7575771d684e1e249177374f1dcf53fed6e7eb6)
- todo-listをmat-cardの繰り返しに変更 [b049dce](https://github.com/yasu307/todo-app-angular/pull/5/commits/b049dcec3992a281ddca37adae63aa2cd76c36f7)

## 画面変更
### Todo一覧画面(変更)
path:  todo/list
変更内容
- 背景色を#fafafaに変更
- todo-listをmat-cardの繰り返しに変更
<img width="1792" alt="angular5 todo:list" src="https://user-images.githubusercontent.com/29055153/174751143-ce64a32b-52ad-4b7d-acb3-5e31f0849b73.png">
