### PR TITLE
モデルにあるデータソースの変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ testem.log
 # System files
 .DS_Store
 Thumbs.db
+
+.metals/*

--- a/src/app/views/category/category-list/category-list.component.html
+++ b/src/app/views/category/category-list/category-list.component.html
@@ -1,5 +1,5 @@
 
-<ul *ngFor="let category of categories$ | async">
+<ul *ngFor="let category of allCategory$ | async">
   <li>
     {{category | json}}
   </li>

--- a/src/app/views/category/category-list/category-list.component.ts
+++ b/src/app/views/category/category-list/category-list.component.ts
@@ -9,12 +9,12 @@ import { CategoryService } from '../category.service';
   styleUrls: ['./category-list.component.scss']
 })
 export class CategoryListComponent implements OnInit {
-  categories$?: Observable<Category[]>
+  allCategory$: Observable<Category[]> = this.categoryService.allCategory$
 
   constructor(private categoryService: CategoryService) { }
 
   ngOnInit(): void {
-    this.categories$ = this.categoryService.getCategories()
+    this.categoryService.fetchAllCategory()
   }
 
 }

--- a/src/app/views/category/category.service.ts
+++ b/src/app/views/category/category.service.ts
@@ -1,20 +1,30 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 import { Category } from '../../models/category';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CategoryService {
+  // allCategoryを格納するSubject
+  private allCategorySource = new ReplaySubject<Category[]>(1)
 
   private categoriesUrl = "api/categories"
 
   constructor(private http: HttpClient) { }
 
-  // 全てのカテゴリを取得する
-  // バックエンドAPIから受け取ったデータをCategory型に変換した結果を返す
-  getCategories(): Observable<Category[]> {
-    return this.http.get<Category[]>(this.categoriesUrl)
+  get allCategory$(): Observable<Category[]> {
+    return this.allCategorySource.asObservable()
+  }
+
+  // allCategoryを更新するコマンド
+  // バックエンドAPIから受け取った結果をallCategorySourceに追加する
+  fetchAllCategory(): void {
+    this.http.get<Category[]>(this.categoriesUrl).subscribe(
+      (fetchResult: Category[]) => {
+        this.allCategorySource.next(fetchResult)
+      }
+    )
   }
 }

--- a/src/app/views/todo/todo-form-dialog/todo-form-dialog.component.html
+++ b/src/app/views/todo/todo-form-dialog/todo-form-dialog.component.html
@@ -1,3 +1,3 @@
 <mat-dialog-content>
-  <app-todo-form [selectedTodo]="selectedTodo" (isFinishedEvent)="finishDialog($event)"></app-todo-form>
+  <app-todo-form [selectedTodo]="data.selectedTodo" [allCategory$]="data.allCategory$" (isFinishedEvent)="finishDialog($event)"></app-todo-form>
 </mat-dialog-content>

--- a/src/app/views/todo/todo-form-dialog/todo-form-dialog.component.ts
+++ b/src/app/views/todo/todo-form-dialog/todo-form-dialog.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Todo } from 'src/app/models/todo';
+import { Observable } from 'rxjs';
+import { Category } from 'src/app/models/category';
 
 @Component({
   selector: 'app-todo-form-dialog',
@@ -11,7 +13,7 @@ export class TodoFormDialogComponent implements OnInit {
 
   constructor(
     private dialogRef: MatDialogRef<TodoFormDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public selectedTodo?: Todo
+    @Inject(MAT_DIALOG_DATA) public data: {selectedTodo?: Todo, allCategory$: Observable<Category[]>}
   ) { }
 
   ngOnInit(): void {

--- a/src/app/views/todo/todo-form/todo-form.component.html
+++ b/src/app/views/todo/todo-form/todo-form.component.html
@@ -4,7 +4,7 @@
 <form [formGroup]="todoFormGroup" class="todo-form">
   <!-- カテゴリ　ラジオボタン -->
   <p>
-    <mat-radio-group *ngIf="(allCategoryTakeOnce$ | async) as allCategory" formControlName="categoryId">
+    <mat-radio-group *ngIf="(allCategory$ | async) as allCategory" formControlName="categoryId">
       <mat-label class="todo-form__category-label">カテゴリ</mat-label>
       <mat-radio-button class="todo-form__category-item" *ngFor="let category of allCategory" [value]="category.id" [style.--color]="category.color | colorToRgb">{{category.slug}}</mat-radio-button>
     </mat-radio-group>

--- a/src/app/views/todo/todo-form/todo-form.component.html
+++ b/src/app/views/todo/todo-form/todo-form.component.html
@@ -4,9 +4,9 @@
 <form [formGroup]="todoFormGroup" class="todo-form">
   <!-- カテゴリ　ラジオボタン -->
   <p>
-    <mat-radio-group *ngIf="(categories$ | async) as categories" formControlName="categoryId">
+    <mat-radio-group *ngIf="(allCategory$ | async) as allCategory" formControlName="categoryId">
       <mat-label class="todo-form__category-label">カテゴリ</mat-label>
-      <mat-radio-button class="todo-form__category-item" *ngFor="let category of categories" [value]="category.id" [style.--color]="category.color | colorToRgb">{{category.slug}}</mat-radio-button>
+      <mat-radio-button class="todo-form__category-item" *ngFor="let category of allCategory" [value]="category.id" [style.--color]="category.color | colorToRgb">{{category.slug}}</mat-radio-button>
     </mat-radio-group>
     <mat-error *ngIf="todoFormGroup.get('categoryId')?.hasError('required')">
       カテゴリは必須です

--- a/src/app/views/todo/todo-form/todo-form.component.html
+++ b/src/app/views/todo/todo-form/todo-form.component.html
@@ -4,7 +4,7 @@
 <form [formGroup]="todoFormGroup" class="todo-form">
   <!-- カテゴリ　ラジオボタン -->
   <p>
-    <mat-radio-group *ngIf="(allCategory$ | async) as allCategory" formControlName="categoryId">
+    <mat-radio-group *ngIf="(allCategoryTakeOnce$ | async) as allCategory" formControlName="categoryId">
       <mat-label class="todo-form__category-label">カテゴリ</mat-label>
       <mat-radio-button class="todo-form__category-item" *ngFor="let category of allCategory" [value]="category.id" [style.--color]="category.color | colorToRgb">{{category.slug}}</mat-radio-button>
     </mat-radio-group>

--- a/src/app/views/todo/todo-form/todo-form.component.ts
+++ b/src/app/views/todo/todo-form/todo-form.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { CategoryService } from 'src/app/views/category/category.service';
-import { Observable, tap, catchError } from 'rxjs';
+import { Observable, tap, catchError, take } from 'rxjs';
 import { Category } from 'src/app/models/category';
 import { getStateFromCode, Todo } from 'src/app/models/todo';
 import { TodoService } from '../todo.service';
@@ -15,7 +15,13 @@ import { MyErrorHandler } from 'src/app/utility/error-handler';
 })
 export class TodoFormComponent implements OnInit {
   todoFormGroup!: FormGroup
-  allCategory$?:  Observable<Category[]> = this.categoryService.allCategory$
+
+  // 一度しか取得しないallCategory
+  // 以前にCategoryService.featchAllCategoryを実行していれば、その時に取得した値が
+  // 以前に実行していなければ、このComponentのngOnInitで実行されるfetchAllCategoryの結果が格納される
+  //
+  // Form作成後にこの値が更新されるとカテゴリのラジオボタンについているAutoFocusが消えてしまうため、このような処理にした
+  allCategoryTakeOnce$?:  Observable<Category[]> = this.categoryService.allCategory$.pipe(take(1))
 
   // stateOptionsの選択肢を持つ配列
   stateOptArray = Object.values(StateOptions)

--- a/src/app/views/todo/todo-form/todo-form.component.ts
+++ b/src/app/views/todo/todo-form/todo-form.component.ts
@@ -15,7 +15,7 @@ import { MyErrorHandler } from 'src/app/utility/error-handler';
 })
 export class TodoFormComponent implements OnInit {
   todoFormGroup!: FormGroup
-  categories$?:   Observable<Category[]>
+  allCategory$?:  Observable<Category[]> = this.categoryService.allCategory$
 
   // stateOptionsの選択肢を持つ配列
   stateOptArray = Object.values(StateOptions)
@@ -51,7 +51,7 @@ export class TodoFormComponent implements OnInit {
     // そのため、TODOがすでに選択されていて、操作ができない状態になる
     if (!this.selectedTodo) this.todoFormGroup.controls["stateCode"].disable()
 
-    this.categories$ = this.categoryService.getCategories()
+    this.categoryService.fetchAllCategory()
   }
 
   // todoを追加するメソッド

--- a/src/app/views/todo/todo-form/todo-form.component.ts
+++ b/src/app/views/todo/todo-form/todo-form.component.ts
@@ -16,19 +16,14 @@ import { MyErrorHandler } from 'src/app/utility/error-handler';
 export class TodoFormComponent implements OnInit {
   todoFormGroup!: FormGroup
 
-  // 一度しか取得しないallCategory
-  // 以前にCategoryService.featchAllCategoryを実行していれば、その時に取得した値が
-  // 以前に実行していなければ、このComponentのngOnInitで実行されるfetchAllCategoryの結果が格納される
-  //
-  // Form作成後にこの値が更新されるとカテゴリのラジオボタンについているAutoFocusが消えてしまうため、このような処理にした
-  allCategoryTakeOnce$?:  Observable<Category[]> = this.categoryService.allCategory$.pipe(take(1))
-
   // stateOptionsの選択肢を持つ配列
   stateOptArray = Object.values(StateOptions)
 
   // Todo追加フォームの場合 undefined
   // Todo更新フォームの場合 Todo
   @Input() selectedTodo?: Todo
+
+  @Input() allCategory$!: Observable<Category[]>
 
   pageTitle?: string
 
@@ -56,8 +51,6 @@ export class TodoFormComponent implements OnInit {
     // todo追加フォームだった場合は、FormGroup作成時にstateCodeをTODO.codeに設定している
     // そのため、TODOがすでに選択されていて、操作ができない状態になる
     if (!this.selectedTodo) this.todoFormGroup.controls["stateCode"].disable()
-
-    this.categoryService.fetchAllCategory()
   }
 
   // todoを追加するメソッド

--- a/src/app/views/todo/todo-list/todo-list.component.html
+++ b/src/app/views/todo/todo-list/todo-list.component.html
@@ -1,7 +1,7 @@
 <!-- 全てのtodoのリスト -->
 <div class="todo-list-component">
   <h2 class="todo-list-component__title">Todo 一覧</h2>
-  <mat-card class="todo-item" *ngFor="let todo of (todos$ | async)">
+  <mat-card class="todo-item" *ngFor="let todo of (allTodo$ | async)">
     <!-- タイトル -->
     <mat-card-title class="todo-item__title">{{todo.title}}</mat-card-title>
     <!-- 補足情報 -->

--- a/src/app/views/todo/todo-list/todo-list.component.html
+++ b/src/app/views/todo/todo-list/todo-list.component.html
@@ -9,7 +9,7 @@
       <!-- ステータス -->
       <p class="todo-item__status">{{todo.state.name}}</p>
       <!-- 対応するカテゴリ -->
-      <p class="todo-item__category" *ngIf="getCategoryById(todo.categoryId, categories$|async) as category" >
+      <p class="todo-item__category" *ngIf="getCategoryById(todo.categoryId, allCategory$|async) as category" >
         <!-- カテゴリの色 -->
         <fa-icon class="todo-item__category-color" [icon]="faCircle" [style.color]="category.color | colorToRgb"></fa-icon>
         <!-- カテゴリのスラグ -->

--- a/src/app/views/todo/todo-list/todo-list.component.ts
+++ b/src/app/views/todo/todo-list/todo-list.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Todo } from '../../../models/todo';
 import { TodoService } from '../todo.service';
-import { Observable, tap, catchError } from 'rxjs';
+import { Observable, tap, catchError, take } from 'rxjs';
 import { Category } from 'src/app/models/category';
 import { CategoryService } from 'src/app/views/category/category.service';
 import { faEdit, faTrashAlt } from '@fortawesome/free-regular-svg-icons';
@@ -44,7 +44,15 @@ export class TodoListComponent implements OnInit {
 
   // todo更新ダイアログを表示する
   showEditDialog(todo: Todo){
-    const editDialogRef = this.dialog.open(TodoFormDialogComponent, { data: todo, width: '700px'})
+    const editDialogRef = this.dialog.open(TodoFormDialogComponent,
+      {
+        data:
+          {
+          selectedTodo: todo,
+          allCategory$: this.categoryService.allCategory$.pipe(take(1))
+          },
+        width: '700px'
+      })
   }
 
   deleteComponent(todoId: number) {
@@ -61,6 +69,13 @@ export class TodoListComponent implements OnInit {
 
   // todo追加ダイアログを表示する
   showStoreDialog() {
-    const storeDialogRef = this.dialog.open(TodoFormDialogComponent, { width: '700px'})
+    const storeDialogRef = this.dialog.open(TodoFormDialogComponent,
+    {
+      data:
+      {
+        allCategory$: this.categoryService.allCategory$.pipe(take(1))
+      },
+      width: '700px'
+    })
   }
 }

--- a/src/app/views/todo/todo-list/todo-list.component.ts
+++ b/src/app/views/todo/todo-list/todo-list.component.ts
@@ -16,7 +16,7 @@ import { MyErrorHandler } from 'src/app/utility/error-handler';
   styleUrls: ['./todo-list.component.scss'],
 })
 export class TodoListComponent implements OnInit {
-  todos$?:       Observable<Todo[]>     = this.todoService.allTodo$
+  allTodo$?:     Observable<Todo[]>     = this.todoService.allTodo$
   allCategory$?: Observable<Category[]> = this.categoryService.allCategory$
 
   faEdit       = faEdit

--- a/src/app/views/todo/todo-list/todo-list.component.ts
+++ b/src/app/views/todo/todo-list/todo-list.component.ts
@@ -16,8 +16,8 @@ import { MyErrorHandler } from 'src/app/utility/error-handler';
   styleUrls: ['./todo-list.component.scss'],
 })
 export class TodoListComponent implements OnInit {
-  todos$?:      Observable<Todo[]>     = this.todoService.allTodo$
-  categories$?: Observable<Category[]>
+  todos$?:       Observable<Todo[]>     = this.todoService.allTodo$
+  allCategory$?: Observable<Category[]> = this.categoryService.allCategory$
 
   faEdit       = faEdit
   faTrashAlt   = faTrashAlt
@@ -33,7 +33,7 @@ export class TodoListComponent implements OnInit {
 
   ngOnInit(): void {
     this.todoService.fetchAllTodo()
-    this.categories$ = this.categoryService.getCategories()
+    this.categoryService.fetchAllCategory()
   }
 
   // idから対応するカテゴリを取得するメソッド

--- a/src/app/views/todo/todo.service.ts
+++ b/src/app/views/todo/todo.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Todo } from '../../models/todo';
-import { Observable, Subject } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 
 @Injectable({
@@ -8,7 +8,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 })
 export class TodoService {
   // allTodoを格納するSubject
-  private allTodoSource = new Subject<Todo[]>()
+  private allTodoSource = new ReplaySubject<Todo[]>(1)
 
   private todosUrl = "api/todos"
   httpOptions = {


### PR DESCRIPTION
## 変更内容
- カテゴリのモデルをコマンドクエリ方式に変更 [2788ad9](https://github.com/yasu307/todo-app-angular/pull/6/commits/2788ad986b24434dfbf7e6c29ac2462a6d2f78ba)
  - データソースをSubjectに格納するとバグが発生したため、ReplaySubjectに格納した
- todoのデータソースはSubjectに格納していても問題はないが、カテゴリに合わせてReplaySubjectに格納 [a895007](https://github.com/yasu307/todo-app-angular/pull/6/commits/a89500725cb33d7efb6bf1209a76e9109859fa01)
- TodoFormComponentにてカテゴリデータを一度のみ取得し、その後更新しないように変更 [87cd662](https://github.com/yasu307/todo-app-angular/pull/6/commits/87cd6628f865122dc4ac3ccf12e2420c44e1efef)
  - これにより、Form作成後にカテゴリデータが更新されるとカテゴリのラジオボタンについているAutoFocusが消えてしまう問題を解決

## 画面変更
なし