### PR TITLE
PlayApiとの接続処理の作成

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,6 +65,14 @@
               "extractLicenses": false,
               "sourceMap": true,
               "namedChunks": true
+            },
+            "local": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.local.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"
@@ -72,6 +80,9 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
+            "local" : {
+              "browserTarget": "todo-app-angular:build:local"
+            },
             "production": {
               "browserTarget": "todo-app-angular:build:production"
             },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,14 +1,13 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
-import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
-import { InMemoryDataService } from './models/in-memory-data/in-memory-data.service';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { TodoModule } from './views/todo/todo.module';
 import { CategoryModule } from './views/category/category.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { EnvironmentModule } from 'src/environments/environment';
 
 @NgModule({
   declarations: [
@@ -18,12 +17,10 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     BrowserModule,
     AppRoutingModule,
     HttpClientModule,
-    // HttpClientInMemoryWebApiModule.forRoot(
-    //   InMemoryDataService, { dataEncapsulation: false, delay: 500 }
-    // ),
     TodoModule,
     CategoryModule,
     BrowserAnimationsModule,
+    EnvironmentModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,9 +18,9 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     BrowserModule,
     AppRoutingModule,
     HttpClientModule,
-    HttpClientInMemoryWebApiModule.forRoot(
-      InMemoryDataService, { dataEncapsulation: false, delay: 500 }
-    ),
+    // HttpClientInMemoryWebApiModule.forRoot(
+    //   InMemoryDataService, { dataEncapsulation: false, delay: 500 }
+    // ),
     TodoModule,
     CategoryModule,
     BrowserAnimationsModule,

--- a/src/app/models/category.ts
+++ b/src/app/models/category.ts
@@ -22,12 +22,12 @@ export interface Color {
 
 // Colorの選択肢
 export const ColorOptions = {
-  RED:     { code: 1, rgb: { red: 255, green: 51, blue: 51}},
-  GREEN:   { code: 2, rgb: { red: 51, green: 255, blue: 51 } },
-  BLUE:    { code: 3, rgb: { red: 51, green: 102, blue: 255 } },
-  YELLOW:  { code: 4, rgb: { red: 255, green: 255, blue: 102 } },
-  AQUA:    { code: 5, rgb: { red: 102, green: 255, blue: 255 } },
-  FUCHSIA: { code: 6, rgb: { red: 255, green: 102, blue: 255 } },
+  RED:     { code: 0, rgb: { red: 255, green: 51, blue: 51}},
+  GREEN:   { code: 1, rgb: { red: 51, green: 255, blue: 51 } },
+  BLUE:    { code: 2, rgb: { red: 51, green: 102, blue: 255 } },
+  YELLOW:  { code: 3, rgb: { red: 255, green: 255, blue: 102 } },
+  AQUA:    { code: 4, rgb: { red: 102, green: 255, blue: 255 } },
+  FUCHSIA: { code: 5, rgb: { red: 255, green: 102, blue: 255 } },
 } as const;
 
 // ColorからRGBを表す文字列に変換するパイプ

--- a/src/app/models/todo.ts
+++ b/src/app/models/todo.ts
@@ -19,9 +19,9 @@ export interface State{
 
 // Stateの選択肢
 export const StateOptions = {
-  TODO:      { code: 1, name: "TODO" },
-  WORKING:   { code: 2, name: "進行中" },
-  COMPLETED: { code: 3, name: "完了" },
+  TODO:      { code: 0, name: "TODO" },
+  WORKING:   { code: 1, name: "進行中" },
+  COMPLETED: { code: 2, name: "完了" },
 } as const;
 
 // state.codeからstateを取得するメソッド

--- a/src/app/utility/error-handler.ts
+++ b/src/app/utility/error-handler.ts
@@ -12,13 +12,14 @@ export class MyErrorHandler{
     private snackBar: SnackBar
   ){ }
 
-  handleError<T>(operation = 'operation', result ?: T) {
+  handleError<T>(operation = 'operation', altResult ?: T) {
     return (error: any): Observable<T> => {
-      // toastを使いエラーが発生したことをユーザに伝える
-      this.snackBar.displaySnackBar(`${operation} failed: ${error.body.error}`, '', { duration: 4000 })
-
-      // 引数で受け取ったresultを返す
-      return of(result as T);
+      // error.errorが存在すればerror.errorを、存在しなければerrorをエラーメッセージとする
+      const errorMessage = "error" in error ? JSON.stringify(error.error) : JSON.stringify(error)
+      // toastを用いてユーザにエラーメッセージを表示する
+      this.snackBar.displaySnackBar(`${operation} failed: ${errorMessage}`, '', { duration: 4000 })
+      // 引数で受け取ったaltResultを返す
+      return of(altResult as T);
     };
   }
 }

--- a/src/app/views/category/category-form/category-form.component.ts
+++ b/src/app/views/category/category-form/category-form.component.ts
@@ -52,7 +52,7 @@ export class CategoryFormComponent implements OnInit {
       // DBにカテゴリを追加する
       this.categoryService.addCategory(categoryFromFormVal).pipe(
         // 追加が成功したら
-        tap((addedCategory: Category) => {
+        tap((addedCategoryId: any) => {
           // allCategorySourceを更新する
           this.categoryService.fetchAllCategory()
         }),

--- a/src/app/views/category/category.service.ts
+++ b/src/app/views/category/category.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, ReplaySubject } from 'rxjs';
 import { Category } from '../../models/category';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,7 @@ export class CategoryService {
   // allCategoryを格納するSubject
   private allCategorySource = new ReplaySubject<Category[]>(1)
 
-  private categoriesUrl = "http://localhost:9000/api/categories"
+  private categoriesUrl = `${environment.apiUrl}/api/categories`
   httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };

--- a/src/app/views/category/category.service.ts
+++ b/src/app/views/category/category.service.ts
@@ -32,7 +32,7 @@ export class CategoryService {
   }
 
   // カテゴリを追加するコマンド
-  addCategory(category: Category): Observable<Category> {
+  addCategory(category: Category): Observable<any> {
     return this.http.post<Category>(this.categoriesUrl, category, this.httpOptions)
   }
 

--- a/src/app/views/category/category.service.ts
+++ b/src/app/views/category/category.service.ts
@@ -10,7 +10,7 @@ export class CategoryService {
   // allCategoryを格納するSubject
   private allCategorySource = new ReplaySubject<Category[]>(1)
 
-  private categoriesUrl = "api/categories"
+  private categoriesUrl = "http://localhost:9000/api/categories"
   httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };

--- a/src/app/views/category/category.service.ts
+++ b/src/app/views/category/category.service.ts
@@ -38,7 +38,8 @@ export class CategoryService {
 
   // カテゴリを更新するコマンド
   updateCategory(category: Category): Observable<Category> {
-    return this.http.put<Category>(this.categoriesUrl, category, this.httpOptions)
+    const url = `${this.categoriesUrl}/${category.id}`
+    return this.http.put<Category>(url, category, this.httpOptions)
   }
 
   // カテゴリを削除するコマンド

--- a/src/app/views/todo/todo-form/todo-form.component.ts
+++ b/src/app/views/todo/todo-form/todo-form.component.ts
@@ -62,7 +62,7 @@ export class TodoFormComponent implements OnInit {
       // DBにtodoを追加する
       this.todoService.addTodo(todoFromFormVal).pipe(
         // 追加が成功したら
-        tap((addedTodo: Todo) => {
+        tap((addedTodoId: any) => {
           // allTodoSourceを更新する
           this.todoService.fetchAllTodo()
         }),

--- a/src/app/views/todo/todo.service.ts
+++ b/src/app/views/todo/todo.service.ts
@@ -35,8 +35,7 @@ export class TodoService {
   }
 
   // todoを追加するコマンド
-  addTodo(todo: Todo): Observable<Todo>{
-    console.log("inside of addTodo")
+  addTodo(todo: Todo): Observable<any>{
     return this.http.post<Todo>(this.todosUrl, todo, this.httpOptions)
   }
 

--- a/src/app/views/todo/todo.service.ts
+++ b/src/app/views/todo/todo.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Todo } from '../../models/todo';
 import { Observable, ReplaySubject } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,7 @@ export class TodoService {
   // allTodoを格納するSubject
   private allTodoSource = new ReplaySubject<Todo[]>(1)
 
-  private todosUrl = "http://localhost:9000/api/todos"
+  private todosUrl = `${environment.apiUrl}/api/todos`
   httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };

--- a/src/app/views/todo/todo.service.ts
+++ b/src/app/views/todo/todo.service.ts
@@ -10,7 +10,7 @@ export class TodoService {
   // allTodoを格納するSubject
   private allTodoSource = new ReplaySubject<Todo[]>(1)
 
-  private todosUrl = "api/todos"
+  private todosUrl = "http://localhost:9000/api/todos"
   httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' })
   };

--- a/src/app/views/todo/todo.service.ts
+++ b/src/app/views/todo/todo.service.ts
@@ -41,7 +41,8 @@ export class TodoService {
 
   // todoを更新するコマンド
   updateTodo(todo: Todo): Observable<Todo>{
-    return this.http.put<Todo>(this.todosUrl, todo, this.httpOptions)
+    const url = `${this.todosUrl}/${todo.id}`
+    return this.http.put<Todo>(url, todo, this.httpOptions)
   }
 
   // todoを削除するコマンド

--- a/src/environments/environment.local.ts
+++ b/src/environments/environment.local.ts
@@ -1,0 +1,24 @@
+// local開発用
+// in-memory-dataからデータを取得する
+// ng serve -c local で起動
+
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { HttpClientInMemoryWebApiModule } from 'angular-in-memory-web-api';
+import { InMemoryDataService } from "src/app/models/in-memory-data/in-memory-data.service";
+
+@NgModule({
+  imports: [
+    CommonModule,
+    HttpClientInMemoryWebApiModule.forRoot(
+      InMemoryDataService, { dataEncapsulation: false, delay: 500 }
+    ),
+  ],
+})
+export class EnvironmentModule {
+}
+
+export const environment = {
+  production: false,
+  apiUrl:     ''
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,17 @@
+// 本番用もEnvironmentModuleを設定しないとエラーが発生するので
+// とりあえずデフォルトの設定を記述
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ]
+})
+export class EnvironmentModule {
+}
+
 export const environment = {
-  production: true
+  production: true,
+  apiUrl:     'http://localhost:9000'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,16 +1,15 @@
-// This file can be replaced during build by using the `fileReplacements` array.
-// `ng build` replaces `environment.ts` with `environment.prod.ts`.
-// The list of file replacements can be found in `angular.json`.
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+
+@NgModule({
+  imports: [
+    CommonModule,
+  ]
+})
+export class EnvironmentModule {
+}
 
 export const environment = {
-  production: false
+  production: false,
+  apiUrl:     'http://localhost:9000'
 };
-
-/*
- * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
- *
- * This import should be commented out in production mode because it will have a negative impact
- * on performance if an error is thrown.
- */
-// import 'zone.js/plugins/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
## 変更内容
[d8498d3](https://github.com/yasu307/todo-app-angular/pull/8/commits/d8498d3c43e0ac4af95fe8541db8741137f6c142)
- Backendの接続先をInMemoryDataからPlayApiに変更

[77b4149](https://github.com/yasu307/todo-app-angular/pull/8/commits/77b4149d783466f3550faf0e0d0e66c5fe6971b7)
- PlayApiではEnumのcodeが0から始まっていたので、Angularでもそれに合わせた

[1a864a7](https://github.com/yasu307/todo-app-angular/pull/8/commits/1a864a75db2d84e692399c49aba374265383a7a1)
- todo/categoryを追加するApiの返り値が追加したデータのidなので、それに合わせてAngularのメソッドの変更
- Apiから帰ってくるエラーに合わせてエラー処理を変更

## 画面変更
なし